### PR TITLE
Using title, body in form without the language prefix

### DIFF
--- a/src/Controller/ArticlesController.php
+++ b/src/Controller/ArticlesController.php
@@ -41,8 +41,8 @@ class ArticlesController extends AppController
 
     public function view($slug = null)
     {
-        I18n::setLocale('en_GB');
-        // I18n::setLocale('es_AR');
+        // I18n::setLocale('en_GB');
+        I18n::setLocale('es_AR');
         // $this->Articles->setLocale('es_AR');
 
         // Update retrieving tags with contain()
@@ -53,13 +53,13 @@ class ArticlesController extends AppController
             ->contain('Tags')
             ->firstOrFail();
 
-        // pr("Current language es_AR ->title : " . $article->title);
+        pr("Current language es_AR ->title : " . $article->title);
 
         // This will print the details
-        // pr("Using ->translation('es_AR')->title : " . $article->translation('es_AR')->title);
+        pr("Using ->translation('es_AR')->title : " . $article->translation('es_AR')->title);
 
         // Not printing anything
-        // pr("Using ->translation('en_GB')->title : " . $article->translation('en_GB')->title);
+        pr("Using ->translation('en_GB')->title : " . $article->translation('en_GB')->title);
 
         // pr($article);
         // exit;

--- a/src/Controller/ArticlesController.php
+++ b/src/Controller/ArticlesController.php
@@ -19,30 +19,47 @@ class ArticlesController extends AppController
     public function initialize(): void
     {
         parent::initialize();
-
-        I18n::setLocale('en_AR');
     }
 
     public function index()
     {
-        // Paginate the ORM table.
-        // $this->set('articles', $this->paginate($this->Articles));
+        I18n::setLocale('es_AR');
+        // I18n::setLocale('en_GB');
+        // $this->Articles->setLocale('en_GB');
 
         // Paginate a partially completed query
-        // $query = $this->Articles->find();
-        $this->set('articles', $this->paginate($this->Articles->find('translations')));
+        $query = $this->Articles->find('translations');
+
+        // foreach ($query as $r) {
+        //     pr($r->title);
+        // }
+        // exit;
+
+        // Paginate the ORM table.
+        $this->set('articles', $this->paginate($query));
     }
 
     public function view($slug = null)
     {
         I18n::setLocale('en_GB');
+        // I18n::setLocale('es_AR');
+        // $this->Articles->setLocale('es_AR');
 
         // Update retrieving tags with contain()
         $article = $this->Articles
             ->find('translations')
+            // ->find()
             ->where(['slug' => $slug])
             ->contain('Tags')
             ->firstOrFail();
+
+        // pr("Current language es_AR ->title : " . $article->title);
+
+        // This will print the details
+        // pr("Using ->translation('es_AR')->title : " . $article->translation('es_AR')->title);
+
+        // Not printing anything
+        // pr("Using ->translation('en_GB')->title : " . $article->translation('en_GB')->title);
 
         // pr($article);
         // exit;

--- a/templates/Articles/add.php
+++ b/templates/Articles/add.php
@@ -5,14 +5,16 @@
 echo $this->Form->create($article);
 // Hard code the user for now.
 echo $this->Form->control('user_id', ['type' => 'hidden', 'value' => 1]);
-// echo $this->Form->control('title');
-// echo $this->Form->control('body', ['rows' => '3']);
+echo $this->Form->control('title');
+echo $this->Form->control('body', ['rows' => '3']);
 ?>
+<? /*
 <fieldset>
     <legend>English</legend>
     <?= $this->Form->control('_translations.en_GB.title'); ?>
-    <?= $this->Form->control('_translations.en_GB.body', ['rows' => '3']); ?>
+<?= $this->Form->control('_translations.en_GB.body', ['rows' => '3']); ?>
 </fieldset>
+*/ ?>
 <fieldset>
     <legend>Spanish</legend>
     <?= $this->Form->control('_translations.es_AR.title'); ?>

--- a/templates/Articles/edit.php
+++ b/templates/Articles/edit.php
@@ -4,13 +4,16 @@
 <?php
 echo $this->Form->create($article);
 echo $this->Form->control('user_id', ['type' => 'hidden']);
-// echo $this->Form->control('title');
+echo $this->Form->control('title');
+echo $this->Form->control('body', ['rows' => '3']);
 ?>
+<? /*
 <fieldset>
     <legend>English</legend>
     <?= $this->Form->control('_translations.en_GB.title'); ?>
-    <?= $this->Form->control('_translations.en_GB.body', ['rows' => '3']); ?>
+<?= $this->Form->control('_translations.en_GB.body', ['rows' => '3']); ?>
 </fieldset>
+*/ ?>
 <fieldset>
     <legend>Spanish</legend>
     <?= $this->Form->control('_translations.es_AR.title'); ?>

--- a/templates/Articles/index.php
+++ b/templates/Articles/index.php
@@ -14,7 +14,7 @@
     <?php foreach ($articles as $article) : ?>
         <tr>
             <td>
-                <?= $this->Html->link($article->translation('es_AR')->title, ['action' => 'view', $article->slug]) ?>
+                <?= $this->Html->link($article->title, ['action' => 'view', $article->slug]) ?>
             </td>
             <td>
                 <?= $article->created->format(DATE_RFC850) ?>


### PR DESCRIPTION
When we change the form fields 

```
echo $this->Form->control('title');
echo $this->Form->control('body', ['rows' => '3']);
?>
<? /*
<fieldset>
    <legend>English</legend>
    <?= $this->Form->control('_translations.en_GB.title'); ?>
<?= $this->Form->control('_translations.en_GB.body', ['rows' => '3']); ?>
</fieldset>
*/ ?>
<fieldset>
    <legend>Spanish</legend>
    <?= $this->Form->control('_translations.es_AR.title'); ?>
    <?= $this->Form->control('_translations.es_AR.body'); ?>
</fieldset>
```

it will stop saving data. add/edit will not work.

Manually added details into the table. So articles table will have title and body. The article_translations have `es_AR` language content also.

The view, edit, add will show the details on the form. But cannot save the form.